### PR TITLE
Add login server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ macOS but should work on any platform that supports Python and Tkinter.
 
 - Python 3
 - Pillow (`pip install -r requirements.txt`)
+- Flask
 
 ## Usage
 
@@ -25,3 +26,15 @@ macOS but should work on any platform that supports Python and Tkinter.
    ```
 
 A window will open and update with a random picture every 15 seconds.
+
+## Login Page
+
+This repository also includes a simple web server that serves `login.html` and
+checks a hard-coded username and password. To run the server:
+
+```bash
+python3 server.py
+```
+
+Visit `http://localhost:5000` in your browser to see the login form. The
+default credentials are `admin` / `secret`.

--- a/login.html
+++ b/login.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Вход</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            background-color: #f4f4f4;
+        }
+        .login-container {
+            background: white;
+            padding: 20px 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            width: 300px;
+        }
+        input[type="text"], input[type="password"] {
+            width: 100%;
+            padding: 8px;
+            margin-bottom: 10px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+        input[type="submit"] {
+            width: 100%;
+            padding: 8px;
+            background: #007BFF;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        input[type="submit"]:hover {
+            background: #0056b3;
+        }
+    </style>
+</head>
+<body>
+    <div class="login-container">
+        <h2>Войти</h2>
+        <form action="/" method="POST">
+            <label for="username">Имя пользователя</label>
+            <input type="text" id="username" name="username" required>
+            <label for="password">Пароль</label>
+            <input type="password" id="password" name="password" required>
+            <input type="submit" value="Войти">
+        </form>
+    </div>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Pillow
+Flask

--- a/server.py
+++ b/server.py
@@ -1,0 +1,21 @@
+from flask import Flask, request, send_from_directory, redirect, url_for
+
+app = Flask(__name__)
+
+USERNAME = 'admin'
+PASSWORD = 'secret'
+
+@app.route('/', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form.get('username', '')
+        password = request.form.get('password', '')
+        if username == USERNAME and password == PASSWORD:
+            return send_from_directory('.', 'success.html')
+        else:
+            # Invalid credentials, reload login page
+            return send_from_directory('.', 'login.html'), 401
+    return send_from_directory('.', 'login.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/success.html
+++ b/success.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Успешный вход</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            background-color: #f4f4f4;
+        }
+    </style>
+</head>
+<body>
+    <h2>Успешный вход</h2>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- modify login form to post to server
- include a simple Flask server and success page
- document login server usage in the README
- add Flask to requirements

## Testing
- `python3 -m py_compile random_image_viewer.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_6840afa987608327a4a82ec5c10fc7b4